### PR TITLE
Added feature for clients to denote that they are ready

### DIFF
--- a/src/components/admin/admin-main.js
+++ b/src/components/admin/admin-main.js
@@ -395,7 +395,7 @@ function AdminMain() {
 
     function getReadyParticipants(meetingId) {
         try {
-            const url = restUrl + 'readyParticipants?meetingId=' + meetingId;
+            const url = restUrl + 'getReadyParticipants?meetingId=' + meetingId;
             fetch(url, {
                 method: 'GET',
                 mode: 'cors',

--- a/src/components/admin/admin-main.js
+++ b/src/components/admin/admin-main.js
@@ -392,10 +392,42 @@ function AdminMain() {
         }
     }
 
+    function getReadyParticipants() {
+        try {
+            const url = restUrl + 'submittedParticipants?meetingId=' + meetingId;
+            fetch(url, {
+                method: 'GET',
+                mode: 'cors',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json',
+                },
+            })
+                .then(response => {
+
+                    if (response.status === 200) {
+                        response.json().then(response => {
+                            var netIds = []
+                            for (let netId in response) {
+                                let id = response[netId];
+                                if (id.startsWith("group_")) {
+                                    netIds.append(id.slice(6)); // remove "group_" prefix
+                                }
+                            }
+                        });
+                    }
+                });
+        }
+        catch (error) {
+            alert('Something went wrong!');
+        }
+    }
+
     useEffect(() => {
         const interval = setInterval(() => {
             if (MeetingActive) {
                 getActiveParticipants(location.state.meetingId);
+                getReadyParticipants(location.state.meetingId);
                 getAccumulatedTranscript(location.state.meetingId);
             }
             if (record == null) {
@@ -410,11 +442,11 @@ function AdminMain() {
             <div style={emotionDetectionPopupStyle}>
                 {MeetingActive &&
                     <div>
-
                         <div style={gridContainer}>
                             <label style={labelStyle}>Active Participants</label>
                             {displayActiveParticipants.map((i) => <button style={userButtonStyle} key={i.name}> {i.name} </button>)}
                         </div>
+                        <button style={promptButtonStyle} onClick={promptSubmission}>Prompt all participants to submit</button>
                         <div style={fullWidth}>
                             <center>
                                 <h2>Meeting ID: {meetingId}</h2>
@@ -436,7 +468,6 @@ function AdminMain() {
                             </center>
                         </div>
                         <br></br><br></br>
-                        <button style={promptButtonStyle} onClick={promptSubmission}>Prompt all participants to submit</button>
                         <button style={finishButtonStyle} onClick={endMeeting}>End Meeting</button>
                     </div>}
                 {!MeetingActive && <div>

--- a/src/components/admin/admin-main.js
+++ b/src/components/admin/admin-main.js
@@ -24,6 +24,7 @@ function AdminMain() {
     const [summary, setSummary] = useState("");
     const [keywords, setKeywords] = useState("");
     const [displayActiveParticipants, setDisplayActiveParticipants] = useState([])
+    const [readyParticipants, setReadyParticipants] = useState([])
 
     // voice pitch
     const [pitch, setPitch] = useState(1);
@@ -392,9 +393,9 @@ function AdminMain() {
         }
     }
 
-    function getReadyParticipants() {
+    function getReadyParticipants(meetingId) {
         try {
-            const url = restUrl + 'submittedParticipants?meetingId=' + meetingId;
+            const url = restUrl + 'readyParticipants?meetingId=' + meetingId;
             fetch(url, {
                 method: 'GET',
                 mode: 'cors',
@@ -407,12 +408,8 @@ function AdminMain() {
 
                     if (response.status === 200) {
                         response.json().then(response => {
-                            var netIds = []
                             for (let netId in response) {
-                                let id = response[netId];
-                                if (id.startsWith("group_")) {
-                                    netIds.append(id.slice(6)); // remove "group_" prefix
-                                }
+                                setReadyParticipants(prevReadyParticipants => [...prevReadyParticipants, response[netId]])
                             }
                         });
                     }
@@ -444,7 +441,8 @@ function AdminMain() {
                     <div>
                         <div style={gridContainer}>
                             <label style={labelStyle}>Active Participants</label>
-                            {displayActiveParticipants.map((i) => <button style={userButtonStyle} key={i.name}> {i.name} </button>)}
+                            {displayActiveParticipants.map((i) => <button style={{...userButtonStyle,  
+                            backgroundColor: readyParticipants.includes(i.name) ? "yellow" : "white"}} key={i.name}> {i.name} </button>)}
                         </div>
                         <button style={promptButtonStyle} onClick={promptSubmission}>Prompt all participants to submit</button>
                         <div style={fullWidth}>

--- a/src/components/admin/admin-main.js
+++ b/src/components/admin/admin-main.js
@@ -24,7 +24,7 @@ function AdminMain() {
     const [summary, setSummary] = useState("");
     const [keywords, setKeywords] = useState("");
     const [displayActiveParticipants, setDisplayActiveParticipants] = useState([])
-    const [readyParticipants, setReadyParticipants] = useState([])
+    const [groupReadyParticipants, setGroupReadyParticipants] = useState([])
 
     // voice pitch
     const [pitch, setPitch] = useState(1);
@@ -407,9 +407,9 @@ function AdminMain() {
         }
     }
 
-    function getReadyParticipants(meetingId) {
+    function getGroupReadyParticipants(meetingId) {
         try {
-            const url = restUrl + 'getReadyParticipants?meetingId=' + meetingId;
+            const url = restUrl + 'getGroupReadyParticipants?meetingId=' + meetingId;
             fetch(url, {
                 method: 'GET',
                 mode: 'cors',
@@ -423,7 +423,7 @@ function AdminMain() {
                     if (response.status === 200) {
                         response.json().then(response => {
                             for (let netId in response) {
-                                setReadyParticipants(prevReadyParticipants => [...prevReadyParticipants, response[netId]])
+                                setGroupReadyParticipants(prevGroupReadyParticipants => [...prevGroupReadyParticipants, response[netId]])
                             }
                         });
                     }
@@ -438,7 +438,7 @@ function AdminMain() {
         const interval = setInterval(() => {
             if (MeetingActive) {
                 getActiveParticipants(location.state.meetingId);
-                getReadyParticipants(location.state.meetingId);
+                getGroupReadyParticipants(location.state.meetingId);
                 getAccumulatedTranscript(location.state.meetingId);
             }
             if (record == null) {
@@ -456,7 +456,7 @@ function AdminMain() {
                         <div style={gridContainer}>
                             <label style={labelStyle}>Active Participants</label>
                             {displayActiveParticipants.map((i) => <button style={{...userButtonStyle,  
-                            backgroundColor: readyParticipants.includes(i.name) ? "yellow" : "white"}} key={i.name}> {i.name} </button>)}
+                            backgroundColor: groupReadyParticipants.includes(i.name) ? "yellow" : "white"}} key={i.name}> {i.name} </button>)}
                         </div>
                         <button style={promptButtonStyle} onClick={promptSubmission}>Prompt all participants to submit</button>
                         <div style={fullWidth}>

--- a/src/components/tasks/desertTask/desert-problem-shared.js
+++ b/src/components/tasks/desertTask/desert-problem-shared.js
@@ -81,7 +81,7 @@ function DesertProblem({ submittable }) {
                     {!submittable ?
                         allReady ? 
                             <div>
-                                <InstructionsParagraph style={{ 'textAlign': "center" }}>
+                                <InstructionsParagraph style={{ 'textAlign': "center", 'padding': '20px', 'width':'90%'}}>
                                     <h3>Submission options will appear once everyone is ready!</h3>
                                 </InstructionsParagraph>
                             </div>

--- a/src/components/tasks/desertTask/desert-problem-shared.js
+++ b/src/components/tasks/desertTask/desert-problem-shared.js
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import { restUrl } from "../../../index";
 import { Container, EmotionDetectionPopupStyle, H3, AreaWidth, ItemWidth, InstructionsArea, InstructionsParagraph, InstructionsBar } from '../task-styles';
 
-const ReadyButton = styled.input`
+const GroupReadyButton = styled.input`
     background-color: #66e29a;
     border: none;
     cursor: pointer;
@@ -24,7 +24,7 @@ function DesertProblem({ submittable }) {
     const { meetingId, netId } = state;
     const [groupReady, setGroupReady] = useState(false);
 
-    const confirmReady = () => {
+    const confirmGroupReady = () => {
         setGroupReady(true);
         try {
             const url = restUrl + 'submitReady';
@@ -87,10 +87,10 @@ function DesertProblem({ submittable }) {
                             </div>
                             :
                             <div>
-                                <ReadyButton
+                                <GroupReadyButton
                                     type="button"
                                     value="Once your group has achieved consensus, press this button!"
-                                    onClick={confirmReady}
+                                    onClick={confirmGroupReady}
                                 />
                             </div>
                         :

--- a/src/components/tasks/desertTask/desert-problem-shared.js
+++ b/src/components/tasks/desertTask/desert-problem-shared.js
@@ -22,10 +22,10 @@ const ReadyButton = styled.input`
 function DesertProblem({ submittable }) {
     const { state } = useLocation();
     const { meetingId, netId } = state;
-    const [allReady, setAllReady] = useState(false);
+    const [groupReady, setGroupReady] = useState(false);
 
     const confirmReady = () => {
-        setAllReady(true);
+        setGroupReady(true);
         try {
             const url = restUrl + 'submitReady';
             fetch(url, {
@@ -79,7 +79,7 @@ function DesertProblem({ submittable }) {
                 </AreaWidth>
                 <ItemWidth>
                     {!submittable ?
-                        allReady ? 
+                        groupReady ? 
                             <div>
                                 <InstructionsParagraph style={{ 'textAlign': "center", 'padding': '20px', 'width':'90%'}}>
                                     <h3>Submission options will appear once everyone is ready!</h3>

--- a/src/components/tasks/desertTask/desert-problem-shared.js
+++ b/src/components/tasks/desertTask/desert-problem-shared.js
@@ -1,10 +1,50 @@
 import { useLocation } from "react-router-dom";
+import styled from "styled-components";
 import DragAndDropWrapper from '../../dragAndDrop/dragAndDropWrapper';
+import React, { useState } from "react";
+import { restUrl } from "../../../index";
 import { Container, EmotionDetectionPopupStyle, H3, AreaWidth, ItemWidth, InstructionsArea, InstructionsParagraph, InstructionsBar } from '../task-styles';
+
+const ReadyButton = styled.input`
+    background-color: #66e29a;
+    border: none;
+    cursor: pointer;
+    width: 80%;
+    padding: 1rem;
+    margin: 0.5rem;
+    font-size: 15px;
+    white-space: normal;
+    align-self: center;
+    margin-top: 2rem;
+    border-radius: 6px;
+`;
 
 function DesertProblem({ submittable }) {
     const { state } = useLocation();
     const { meetingId, netId } = state;
+    const [allReady, setAllReady] = useState(false);
+
+    const confirmReady = () => {
+        setAllReady(true);
+        try {
+            const url = restUrl + 'submitReady';
+            fetch(url, {
+                method: 'POST',
+                mode: 'cors',
+                headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                'netId': 'group_' + netId, // append group_ to netid when ready during group task
+                'meetingId': meetingId,
+                }),
+            })
+        }
+        catch (error) {
+            console.log('error', error);
+        }
+    };
 
     return (
         <Container>
@@ -39,11 +79,20 @@ function DesertProblem({ submittable }) {
                 </AreaWidth>
                 <ItemWidth>
                     {!submittable ?
-                        <div>
-                            <InstructionsParagraph style={{ 'textAlign': "center" }}>
-                                Submission options will appear only after consensus is reached!
-                            </InstructionsParagraph>
-                        </div>
+                        allReady ? 
+                            <div>
+                                <InstructionsParagraph style={{ 'textAlign': "center" }}>
+                                    <h3>Submission options will appear once everyone is ready!</h3>
+                                </InstructionsParagraph>
+                            </div>
+                            :
+                            <div>
+                                <ReadyButton
+                                    type="button"
+                                    value="Once your group has achieved consensus, press this button!"
+                                    onClick={confirmReady}
+                                />
+                            </div>
                         :
                         <div>
                             <InstructionsParagraph style={{ margin: "10px 5em" }}>

--- a/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
+++ b/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
@@ -142,7 +142,7 @@ function HiddenProblem({ submittable }) {
                 'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                'netId': 'group_' + netId, // append group_ to netid when ready during group task
+                'netId': "group_"+netId, // append group_ to netid when ready during group task
                 'meetingId': meetingId,
                 }),
             })

--- a/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
+++ b/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
@@ -187,7 +187,7 @@ function HiddenProblem({ submittable }) {
                     {!submittable ?
                         allReady ? 
                             <div>
-                                <InstructionsParagraph style={{ 'textAlign': "center" }}>
+                                <InstructionsParagraph style={{ 'textAlign': "center", 'padding': '20px', 'width':'90%'}}>
                                     <h3>Submission options will appear once everyone is ready!</h3>
                                 </InstructionsParagraph>
                             </div>

--- a/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
+++ b/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
@@ -25,7 +25,7 @@ const SubmitElementsButton = styled.input`
     ${'' /* border-radius: 6px; */}
 `;
 
-const ReadyButton = styled.input`
+const GroupReadyButton = styled.input`
     background-color: #66e29a;
     border: none;
     cursor: pointer;
@@ -130,7 +130,7 @@ function HiddenProblem({ submittable }) {
         });
     };
 
-    const confirmReady = () => {
+    const confirmGroupReady = () => {
         setGroupReady(true);
         try {
             const url = restUrl + 'submitReady';
@@ -193,10 +193,10 @@ function HiddenProblem({ submittable }) {
                             </div>
                             :
                             <div>
-                                <ReadyButton
+                                <GroupReadyButton
                                     type="button"
                                     value="Once your group has achieved consensus, press this button!"
-                                    onClick={confirmReady}
+                                    onClick={confirmGroupReady}
                                 />
                             </div>
                         :

--- a/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
+++ b/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
@@ -45,7 +45,7 @@ function HiddenProblem({ submittable }) {
     const navigate = useNavigate();
     const location = useLocation();
     const [choice, setChoice] = useState([]);
-    const [allReady, setAllReady] = useState(false);
+    const [groupReady, setGroupReady] = useState(false);
     console.log(submittable);
 
     const infoPieces = {
@@ -131,7 +131,7 @@ function HiddenProblem({ submittable }) {
     };
 
     const confirmReady = () => {
-        setAllReady(true);
+        setGroupReady(true);
         try {
             const url = restUrl + 'submitReady';
             fetch(url, {
@@ -185,7 +185,7 @@ function HiddenProblem({ submittable }) {
 
                 <ItemWidth>
                     {!submittable ?
-                        allReady ? 
+                        groupReady ? 
                             <div>
                                 <InstructionsParagraph style={{ 'textAlign': "center", 'padding': '20px', 'width':'90%'}}>
                                     <h3>Submission options will appear once everyone is ready!</h3>

--- a/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
+++ b/src/components/tasks/hiddenInfoTask/hidden-problem-shared.js
@@ -25,12 +25,27 @@ const SubmitElementsButton = styled.input`
     ${'' /* border-radius: 6px; */}
 `;
 
+const ReadyButton = styled.input`
+    background-color: #66e29a;
+    border: none;
+    cursor: pointer;
+    width: 80%;
+    padding: 1rem;
+    margin: 0.5rem;
+    font-size: 15px;
+    white-space: normal;
+    align-self: center;
+    margin-top: 2rem;
+    border-radius: 6px;
+`;
+
 function HiddenProblem({ submittable }) {
     const { state } = useLocation();
     const { meetingId, netId, participantId } = state;
     const navigate = useNavigate();
     const location = useLocation();
     const [choice, setChoice] = useState([]);
+    const [allReady, setAllReady] = useState(false);
     console.log(submittable);
 
     const infoPieces = {
@@ -115,6 +130,28 @@ function HiddenProblem({ submittable }) {
         });
     };
 
+    const confirmReady = () => {
+        setAllReady(true);
+        try {
+            const url = restUrl + 'submitReady';
+            fetch(url, {
+                method: 'POST',
+                mode: 'cors',
+                headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                'netId': 'group_' + netId, // append group_ to netid when ready during group task
+                'meetingId': meetingId,
+                }),
+            })
+        }
+        catch (error) {
+            console.log('error', error);
+        }
+    };
+
     return (
         <Container>
             <EmotionDetectionPopupStyle>
@@ -148,11 +185,20 @@ function HiddenProblem({ submittable }) {
 
                 <ItemWidth>
                     {!submittable ?
-                        <div>
-                            <InstructionsParagraph style={{ 'textAlign': "center" }}>
-                                Submission options will appear only after consensus is reached!
-                            </InstructionsParagraph>
-                        </div>
+                        allReady ? 
+                            <div>
+                                <InstructionsParagraph style={{ 'textAlign': "center" }}>
+                                    <h3>Submission options will appear once everyone is ready!</h3>
+                                </InstructionsParagraph>
+                            </div>
+                            :
+                            <div>
+                                <ReadyButton
+                                    type="button"
+                                    value="Once your group has achieved consensus, press this button!"
+                                    onClick={confirmReady}
+                                />
+                            </div>
                         :
                         <div>
                             <InstructionsParagraph style={{ 'textAlign': "center" }}>


### PR DESCRIPTION
1. Make sure users are in consensus before submitting:

- Everyone has to press a button that says 'Once your group has achieved consensus, press this button!' to denote that they reached consensus.
- Then a text saying 'Submission options will appear once everyone is ready!' will pop up.
- Once everyone presses the button that says 'Once your group has achieved consensus, press this button!', their names in the active participants box in the admin tab will change to yellow.
- The admin can then release the final submission options for the participants to view.

2. Put the prompt button higher up in the admin page. (right under active participants and above the meeting Id)

These are done for both hidden and desert task